### PR TITLE
Improve stuffs for PHPUnit fixture

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,9 @@
     ],
 
     "minimum-stability": "dev",
-    
+
+    "prefer-stable": true,
+
     "require": {
         "php": "^7.2"
     },
@@ -25,6 +27,12 @@
         ],
         "psr-4":{
             "Ouch\\":"src/Ouch/"
+        }
+    },
+
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
         }
     }
 }

--- a/tests/Unit/HandlersTest.php
+++ b/tests/Unit/HandlersTest.php
@@ -16,7 +16,7 @@ class HandlersTest extends TestCase
     /**
      * setUp method set handlers.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->handlers = new Handlers();
     }


### PR DESCRIPTION
# Changed log

- Adding the `prefer-stable` to be `true` and it can install stable dependencies when setting the `minimum-stability` is `dev`.
- Adding the `autoload-dev` setting for `composer.json` file and it can load testing classes automatically.
- According to the [official PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be the `protected function setUp` method.